### PR TITLE
feat(ui) - rbac / poll for vclusters / hide panel in import mode

### DIFF
--- a/pkg/vcluster-rancher-extension-ui/components/VClusterClusterCreateItem.vue
+++ b/pkg/vcluster-rancher-extension-ui/components/VClusterClusterCreateItem.vue
@@ -21,7 +21,8 @@ export default {
 
   computed: {
     isCreatePage(): boolean {
-      return this.$route.path.includes('/create');
+      const url = new URL(window.location.href)
+      return url.pathname.includes('/create') && !url.searchParams.has('mode')
     }
   },
 

--- a/pkg/vcluster-rancher-extension-ui/components/VclusterCreateModal.vue
+++ b/pkg/vcluster-rancher-extension-ui/components/VclusterCreateModal.vue
@@ -383,7 +383,7 @@ export default defineComponent({
                 <div class="option-content">
                   <span>{{ option.label }}</span>
                   <span v-if="option.disabled" class="text-muted"
-                    >(Not ready)</span
+                    >(No projects associated with this cluster)</span
                   >
                 </div>
               </template>

--- a/pkg/vcluster-rancher-extension-ui/constants.ts
+++ b/pkg/vcluster-rancher-extension-ui/constants.ts
@@ -6,6 +6,7 @@ const RANCHER_CONSTANTS = {
   VCLUSTER_PAGE_ACTIVE_CLASS_NAME: "vcluster-page-active",
   VCLUSTER_PROJECT_LABEL: "loft.sh/vcluster-project-uid",
   VCLUSTER_SERVICE_LABEL: "loft.sh/vcluster-service-uid",
+  VCLUSTER_HOST_CLUSTER_LABEL: "loft.sh/vcluster-host-cluster",
 } as const;
 
 export { PRODUCT_NAME, LOFT_CHART_URL, RANCHER_CONSTANTS };

--- a/pkg/vcluster-rancher-extension-ui/pages/create.vue
+++ b/pkg/vcluster-rancher-extension-ui/pages/create.vue
@@ -13,9 +13,10 @@ import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import { mapGetters, Store } from 'vuex';
 import jsyaml from 'js-yaml';
 
-import { CATALOG, NAMESPACE } from '@shell/config/types';
+import { CATALOG, MANAGEMENT, NAMESPACE } from '@shell/config/types';
 import { LOFT_CHART_URL, PRODUCT_NAME } from '../constants';
 import { areUrlsEquivalent } from '../utils';
+import { PROJECT } from '@shell/config/labels-annotations';
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -182,7 +183,7 @@ rbac:
     },
 
     handleCreateVCluster(cb: AsyncButtonCallback) {
-      const clusterId = this.$route.params.cluster
+      const clusterId = this.$route.params.cluster as string
       const chartName = "vcluster"
       const version = this.$route.query.version
       const inStore = this.$store.getters['currentStore']();
@@ -204,9 +205,17 @@ rbac:
         const allNamespaceObjects = this.$store.getters[`${inStore}/all`](NAMESPACE);
         const namespaceObject = allNamespaceObjects.find((namespace: any) => namespace.id === this.value.metadata.namespace);
         projectId = namespaceObject?.metadata?.labels["field.cattle.io/projectId"];
+
+
+        if (!projectId) {
+          projectId = this.$store.getters['management/all'](MANAGEMENT.PROJECT).filter((p: {
+            id: string
+          }) => p.id.includes(clusterId))?.[0]?.id?.split('/')?.[1];
+        }
       }
 
       if (!projectId) {
+
         cb(false);
         this.$store.dispatch('growl/error', {
           title: 'Error',

--- a/pkg/vcluster-rancher-extension-ui/utils.ts
+++ b/pkg/vcluster-rancher-extension-ui/utils.ts
@@ -1,3 +1,5 @@
+import { ClusterResource } from "./pages/index.vue";
+
 export const getCookie = (name: string) => {
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
@@ -39,4 +41,8 @@ function normalizeUrl(url: string): string {
 
 export function areUrlsEquivalent(url1: string, url2: string): boolean {
   return normalizeUrl(url1) === normalizeUrl(url2);
+}
+
+export function getClusterId(cluster: ClusterResource): string {
+  return cluster.id?.split("/").pop() || "";
 }


### PR DESCRIPTION
Fixes ENG-6330 : add a polling mechanism for refetch clusters every 5 seconds
Fixes ENG-6310 : disabled the cluster options if that cluster doesn't have a project attached to it
Fixes ENG-6302 : Hide the CreateVcluster panel component when the mode on create page is `import` 
