### PR TITLE
feat(ci) - publish helm chart and notify on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,185 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-extension:
+    if: startsWith(github.ref, 'refs/tags/v') == true
+    name: Build vcluster-rancher-extension-ui
+    runs-on: ubuntu-latest
+
+    outputs:
+      release_version: ${{ steps.get_version.outputs.release_version }}
+      previous_tag: ${{ steps.get_version.outputs.previous_tag }}
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          
+      - name: Install dependencies
+        run: yarn install
+      
+      - id: get_version
+        name: Get release version
+        run: |
+          RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> "$GITHUB_OUTPUT"
+      
+      - name: Update package version
+        run: |
+          # Extract version without 'v' prefix for tag
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Tag version: $TAG_VERSION"
+          
+          # This will always match the release tag
+          cd pkg/vcluster-rancher-extension-ui
+          npm version $TAG_VERSION --no-git-tag-version
+          echo "Updated package.json version to $TAG_VERSION"
+      
+      - name: Build and publish package
+        run: |
+          echo "Building package"
+          BUILD_SUCCESS=false
+          
+          if [ -f "./node_modules/@rancher/shell/scripts/build-pkg.sh" ]; then
+            # Use the shell script if available
+            yarn build-pkg vcluster-rancher-extension-ui && BUILD_SUCCESS=true
+          elif [ -d "pkg/vcluster-rancher-extension-ui" ]; then
+            # Directly run build command in the package directory
+            echo "Using direct build command"
+            (cd pkg/vcluster-rancher-extension-ui && yarn build) && BUILD_SUCCESS=true
+          else
+            echo "No build method available"
+          fi
+          
+          if [ "$BUILD_SUCCESS" = false ]; then
+            echo "Error: Build failed"
+            exit 1
+          fi
+          
+          # Publish the package
+          echo "Publishing package"
+          yarn publish-pkgs -s loft-sh/vcluster-rancher-extension-ui
+
+  publish-chart:
+    if: startsWith(github.ref, 'refs/tags/v') == true
+    needs: [build-extension]
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Helm
+        uses: helm/helm-gh-action@v4
+        with:
+          version: v3.14.2
+          
+      - name: Install YQ
+        run: |
+          wget https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64 -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          
+      - name: Update and Commit Helm Chart
+        run: |
+          RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/v!!p')
+          
+          # Need to use loft-bot wit admin permissions to push to main
+          git config --global user.name "loft-bot"
+          git config --global user.email "github@loft.sh"
+          
+          yq e -i ".version = \"${RELEASE_VERSION}\"" charts/vcluster-rancher-extension-ui/Chart.yaml
+          yq e -i ".appVersion = \"${RELEASE_VERSION}\"" charts/vcluster-rancher-extension-ui/Chart.yaml
+          yq e -i ".extension.version = \"${RELEASE_VERSION}\"" charts/vcluster-rancher-extension-ui/values.yaml
+          
+          # Commit changes back to the repository
+          git add charts/vcluster-rancher-extension-ui/
+          git commit -m "chore(chart): update chart version to ${RELEASE_VERSION}"
+          
+          # Use token for authentication
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/loft-sh/vcluster-rancher-extension-ui.git
+          git push --force-with-lease origin HEAD:main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Publish Helm chart
+        run: |
+          RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/v!!p')
+          
+          # Install Helm push plugin
+          helm plugin install https://github.com/chartmuseum/helm-push.git
+          
+          # Add the ChartMuseum repository
+          helm repo add chartmuseum https://charts.loft.sh --username ${{ secrets.CHART_MUSEUM_USER }} --password ${{ secrets.CHART_MUSEUM_PASSWORD }}
+          
+          # Validate the chart first
+          echo "Validating chart"
+          helm lint charts/vcluster-rancher-extension-ui/ || {
+            echo "Warning: Chart validation failed but continuing with release"
+          }
+          
+          # Package the chart with error handling
+          echo "Packaging chart"
+          helm package charts/vcluster-rancher-extension-ui/ || {
+            echo "Error: Helm packaging failed"
+            exit 1
+          }
+          
+          # Push the chart
+          echo "Pushing chart to repository"
+          helm cm-push --force vcluster-rancher-extension-ui-${RELEASE_VERSION}.tgz chartmuseum
+        env:
+          CHART_MUSEUM_USER: ${{ secrets.CHART_MUSEUM_USER }}
+          CHART_MUSEUM_PASSWORD: ${{ secrets.CHART_MUSEUM_PASSWORD }}
+
+  notify_release:
+    needs:
+      - build-extension
+      - publish-chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - id: get_base_branch
+        name: Get base branch for tag
+        run: |
+          RELEASE_VERSION=${{ needs.build-extension.outputs.release_version }}
+          TAG_COMMIT=$(git rev-list -n 1 "$RELEASE_VERSION")
+          BASE_BRANCH=$(git branch -r --contains "$TAG_COMMIT" | grep -v HEAD | sed -e 's/^[[:space:]]*//' -e 's/^origin\///' | head -n 1 || echo "main")
+          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Base branch for $RELEASE_VERSION: $BASE_BRANCH"
+          
+      - name: Notify #product-releases Slack channel
+        uses: loft-sh/github-actions/.github/actions/release-notification@v1
+        with:
+          version: ${{ needs.build-extension.outputs.release_version }}
+          previous_tag: ${{ needs.build-extension.outputs.previous_tag }}
+          changes: 'See changelog link below'
+          target_repo: 'loft-sh/vcluster-rancher-extension-ui'
+          product: 'vCluster Rancher Extension UI'
+          base_branch: ${{ steps.get_base_branch.outputs.base_branch }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }}

--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,7 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-charts
 dist-pkg
 assets
 tmp
+*.tgz

--- a/README.md
+++ b/README.md
@@ -43,8 +43,51 @@ API={RANCHER_API_URL} yarn dev
 
 ## Release process
 
-You need a username and password to chartmuseum to push the new version.
+### Automated release (CI)
+
+The extension is automatically built and published when a new GitHub release is created with a tag (e.g., `v0.1.0`). The CI workflow:
+
+1. Builds the extension package
+2. Updates the Helm chart version to match the release
+3. Commits the chart changes back to the repository
+4. Publishes the extension and chart to the Loft charts repository
+5. Sends a notification about the release
+
+### Manual release
+
+For manual releases, you need credentials for the chart repository:
 
 ```bash
+# Install dependencies first
+yarn install
+
+# Release with version bump
 hack/publish-pkg.sh --bump <major|minor|patch> --user <username> --password <password>
+```
+
+### Testing the release process
+
+You can test the release process without publishing anything:
+
+```bash
+# Dry run mode (builds locally but doesn't push anything)
+hack/publish-pkg.sh --bump <major|minor|patch> --dry-run
+```
+
+## Helm chart
+
+The extension is packaged as a Helm chart and published to the Loft charts repository. The chart:
+
+- Installs the vCluster Rancher Extension UI
+- Configures extension metadata for Rancher
+- Includes compatibility requirements
+
+The chart is maintained in the `charts/vcluster-rancher-extension-ui` directory in this repository.
+
+To use the chart directly:
+
+```bash
+helm repo add loft https://charts.loft.sh
+helm repo update
+helm install vcluster-rancher-extension-ui loft/vcluster-rancher-extension-ui
 ```

--- a/charts/vcluster-rancher-extension-ui/.helmignore
+++ b/charts/vcluster-rancher-extension-ui/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/vcluster-rancher-extension-ui/Chart.yaml
+++ b/charts/vcluster-rancher-extension-ui/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: vcluster-rancher-extension-ui
+description: A Helm chart for the vCluster Rancher Extension UI
+type: application
+# This version will be dynamically updated during the CI process with the git tag
+version: 0.0.3
+appVersion: 0.0.3

--- a/charts/vcluster-rancher-extension-ui/README.md
+++ b/charts/vcluster-rancher-extension-ui/README.md
@@ -1,0 +1,24 @@
+# vCluster Rancher Extension UI Helm Chart
+
+This Helm chart installs the vCluster Rancher Extension UI.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+- Rancher 2.10.0+
+- Rancher UI Extensions 3.0.0+
+
+## Installation
+
+```bash
+helm repo add vcluster https://charts.loft.sh
+helm install vcluster-rancher-extension-ui vcluster/vcluster-rancher-extension-ui
+```
+
+## Configuration
+
+See values.yaml for the available configuration options.
+
+## Release Process
+
+This chart is automatically published by CI when a new release is created in the GitHub repository. The chart version matches the git tag of the release.

--- a/charts/vcluster-rancher-extension-ui/templates/NOTES.txt
+++ b/charts/vcluster-rancher-extension-ui/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Thank you for installing the vCluster Rancher Extension UI chart!
+
+The extension is now available in your Rancher installation.
+
+Compatible with:
+- Rancher: v{{ .Values.rancher.minVersion }} or higher
+- UI Extension System: v{{ .Values.rancher.uiExtensionMinVersion }} up to v{{ .Values.rancher.uiExtensionMaxVersion }}
+
+You can access the vCluster UI extension through the Rancher dashboard.

--- a/charts/vcluster-rancher-extension-ui/templates/configmap.yaml
+++ b/charts/vcluster-rancher-extension-ui/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-extension-config
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  extension.json: |
+    {
+      "name": "vcluster-rancher-extension-ui",
+      "version": "{{ .Values.extension.version }}",
+      "description": "vCluster extension for Rancher UI",
+      "requirements": {
+        "rancher": ">={{ .Values.rancher.minVersion }}",
+        "uiExtension": ">={{ .Values.rancher.uiExtensionMinVersion }} <{{ .Values.rancher.uiExtensionMaxVersion }}"
+      }
+    }

--- a/charts/vcluster-rancher-extension-ui/values.yaml
+++ b/charts/vcluster-rancher-extension-ui/values.yaml
@@ -1,0 +1,13 @@
+# Default values for vcluster-rancher-extension-ui
+image:
+  repository: ghcr.io/loft-sh/vcluster-rancher-extension-ui
+  tag: latest
+  pullPolicy: IfNotPresent
+# UI extension version
+extension:
+  version: 0.0.3
+# Rancher configuration
+rancher:
+  minVersion: "2.10.0"
+  uiExtensionMinVersion: "3.0.0"
+  uiExtensionMaxVersion: "4.0.0"

--- a/hack/publish-pkg.sh
+++ b/hack/publish-pkg.sh
@@ -7,6 +7,41 @@ command -v yarn >/dev/null 2>&1 || {
   exit 1
 }
 
+command -v yq >/dev/null 2>&1 || {
+  echo "yq is required but not installed. Installing..." >&2
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install yq
+  else
+    sudo wget https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64 -O /usr/local/bin/yq
+    sudo chmod +x /usr/local/bin/yq
+  fi
+}
+
+# Parse arguments to detect dry-run
+DRY_RUN=false
+for arg in "$@"; do
+  if [ "$arg" = "--dry-run" ]; then
+    DRY_RUN=true
+    break
+  fi
+done
+
+# Check if dependencies are installed
+if [ ! -d "node_modules" ]; then
+  echo "Dependencies not found."
+  
+  # In dry-run mode, try to install dependencies
+  if [ "$DRY_RUN" = true ]; then
+    echo "Attempting to install dependencies for dry-run testing..."
+    yarn install --frozen-lockfile || {
+      echo "Failed to install dependencies. Continuing in dry-run mode with limited functionality."
+    }
+  else
+    echo "Aborting. Run 'yarn install' first."
+    exit 1
+  fi
+fi
+
 # Function to check if node version meets requirements
 check_node_version() {
   required_version="v20"
@@ -60,6 +95,10 @@ while [[ $# -gt 0 ]]; do
     PASSWORD="$2"
     shift 2
     ;;
+  --dry-run)
+    DRY_RUN=true
+    shift
+    ;;
   *)
     echo "Unknown argument: $1"
     exit 1
@@ -70,24 +109,143 @@ done
 # helm plugin install https://github.com/chartmuseum/helm-push.git
 # helm repo add chartmuseum $CHART_MUSEUM_URL --username $CHART_MUSEUM_USER --password $CHART_MUSEUM_PASSWORD
 
-if [ -z "$BUMP_TYPE" ] || [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+if [ -z "$BUMP_TYPE" ]; then
+  echo "Usage:"
+  echo "  $0 --bump <major|minor|patch> --user <username> --password <password>"
+  echo "  $0 --bump <major|minor|patch> --dry-run"
+  exit 1
+fi
+
+if [ "$DRY_RUN" = false ] && ([ -z "$USERNAME" ] || [ -z "$PASSWORD" ]); then
+  echo "For actual publishing, username and password are required."
   echo "Usage: $0 --bump <major|minor|patch> --user <username> --password <password>"
   exit 1
 fi
 
-# Bump the version based on argument
-yarn run bump-$BUMP_TYPE
+if [ "$DRY_RUN" = true ]; then
+  echo "DRY RUN MODE - No changes will be pushed to remote repositories"
+fi
 
-# Build the package
-yarn build-pkg vcluster-rancher-extension-ui
+# Bump the version based on argument
+if [ "$DRY_RUN" = true ]; then
+  echo "Bumping version ($BUMP_TYPE)"
+  yarn run bump-$BUMP_TYPE || {
+    echo "Warning: Version bump failed but continuing in dry-run mode"
+    echo "    This might be due to missing dependencies"
+    
+    # For testing, simulate a version bump by using an existing version or creating a fake one
+    if [ -f "./pkg/vcluster-rancher-extension-ui/package.json" ]; then
+      echo "Using existing version from package.json"
+    else
+      echo "Creating a simulated version for testing"
+      mkdir -p ./pkg/vcluster-rancher-extension-ui/
+      echo '{"version": "0.0.999-test"}' > ./pkg/vcluster-rancher-extension-ui/package.json
+    fi
+  }
+else
+  yarn run bump-$BUMP_TYPE
+fi
+
+# Build the package locally
+if [ ! -d "node_modules" ] && [ "$DRY_RUN" = true ]; then
+  echo "Warning: Dependencies missing, cannot build package in dry-run mode"
+  echo "For a full test, run 'yarn install' first"
+  
+  # Create directory structure to continue testing
+  mkdir -p pkg/vcluster-rancher-extension-ui 2>/dev/null || true
+else
+  # Try different build approaches
+  echo "Building package"
+  BUILD_SUCCESS=false
+  
+  if [ -f "./node_modules/@rancher/shell/scripts/build-pkg.sh" ]; then
+    # Use the shell script if available
+    yarn build-pkg vcluster-rancher-extension-ui && BUILD_SUCCESS=true
+  elif [ -d "pkg/vcluster-rancher-extension-ui" ]; then
+    # Directly run build command in the package directory
+    echo "Using direct build command"
+    (cd pkg/vcluster-rancher-extension-ui && yarn build) && BUILD_SUCCESS=true
+  else
+    echo "No build method available"
+  fi
+  
+  if [ "$BUILD_SUCCESS" = false ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "Warning: Build failed but continuing in dry-run mode"
+    else
+      echo "Error: Build failed"
+      exit 1
+    fi
+  fi
+fi
 
 # Publish the package
-yarn publish-pkgs -s loft-sh/vcluster-rancher-extension-ui 
+if [ "$DRY_RUN" = false ]; then
+  echo "Publishing package"
+  yarn publish-pkgs -s loft-sh/vcluster-rancher-extension-ui
+else
+  echo "DRY RUN: Skipping package publishing"
+fi 
 
 # Get version from package.json
 VERSION=$(node -p "require('./pkg/vcluster-rancher-extension-ui/package.json').version")
 echo "Package version: $VERSION"
 
-helm plugin install https://github.com/chartmuseum/helm-push.git
-helm repo add chartmuseum https://charts.loft.sh --username $USERNAME --password $PASSWORD
-helm cm-push --force charts/vcluster-rancher-extension-ui/$VERSION/ chartmuseum
+if [ "$DRY_RUN" = false ]; then
+  helm plugin install https://github.com/chartmuseum/helm-push.git
+  helm repo add chartmuseum https://charts.loft.sh --username $USERNAME --password $PASSWORD
+fi
+
+# Always update the chart files
+echo "Updating chart version to $VERSION"
+yq e -i ".version = \"${VERSION}\"" charts/vcluster-rancher-extension-ui/Chart.yaml
+yq e -i ".appVersion = \"${VERSION}\"" charts/vcluster-rancher-extension-ui/Chart.yaml
+yq e -i ".extension.version = \"${VERSION}\"" charts/vcluster-rancher-extension-ui/values.yaml
+
+# Validate the chart first
+echo "Validating chart"
+if ! helm lint charts/vcluster-rancher-extension-ui/ &>/dev/null; then
+  echo "Warning: Chart validation failed"
+  if [ "$DRY_RUN" = false ]; then
+    echo "Would you like to continue anyway? (y/N)"
+    read -r confirm
+    if [[ ! "$confirm" =~ ^[yY]$ ]]; then
+      echo "Aborting release due to chart validation failure"
+      exit 1
+    fi
+    echo "Continuing despite validation issues"
+  fi
+fi
+
+# Package the chart (but don't push)
+echo "Packaging chart"
+helm package charts/vcluster-rancher-extension-ui/ || {
+  if [ "$DRY_RUN" = true ]; then
+    echo "Warning: Helm packaging failed but continuing in dry-run mode"
+    echo "    This might be due to missing internet connection or dependencies"
+    # Create a dummy package for visualization
+    echo "Creating placeholder package file for visualization"
+    touch vcluster-rancher-extension-ui-${VERSION}.tgz
+  else
+    echo "Error: Helm packaging failed"
+    exit 1
+  fi
+}
+
+if [ "$DRY_RUN" = false ]; then
+  # Save changes to git
+  echo "Committing changes to git"
+  git config user.name "loft-bot" || true
+  git config user.email "github@loft.sh" || true
+  git add charts/vcluster-rancher-extension-ui/
+  git commit -m "chore(chart): update chart version to ${VERSION}"
+  git push --force-with-lease origin HEAD:main
+
+  # Push the chart
+  echo "Pushing chart to repository"
+  helm cm-push --force vcluster-rancher-extension-ui-${VERSION}.tgz chartmuseum
+else
+  echo "DRY RUN: Skipping git commit and push"
+  echo "DRY RUN: Skipping helm chart push"
+  echo "DRY RUN: Chart package created: vcluster-rancher-extension-ui-${VERSION}.tgz"
+fi


### PR DESCRIPTION
Closes OPS-118

## Implementation Notes

- Add GitHub Actions workflow for automating release publishing
- Maintain same versioning logic as hack script but source version directly from Git tag
- Add Slack notifications for release updates in the `#product-releases channel`