### PR TITLE
Update vCluster icons and add logo to create buttons

### DIFF
--- a/pkg/vcluster-rancher-extension-ui/assets/vclusterLogoWhite.svg
+++ b/pkg/vcluster-rancher-extension-ui/assets/vclusterLogoWhite.svg
@@ -4,7 +4,7 @@
   <defs>
     <style>
       .st0 {
-        fill: #f60;
+        fill: #fff;
         fill-rule: evenodd;
       }
     </style>

--- a/pkg/vcluster-rancher-extension-ui/components/VClusterClusterCreateItem.vue
+++ b/pkg/vcluster-rancher-extension-ui/components/VClusterClusterCreateItem.vue
@@ -188,7 +188,7 @@ export default {
       <div class="provider-card item color2" @click="openVClusterModal">
         <div class="side-label"></div>
         <div class="provider-logo">
-          <img src="../assets/vclusterLogo.svg" alt="Amazon EKS" />
+          <img src="../assets/vclusterLogo.svg" alt="vCluster" />
         </div>
         <div class="provider-name">vCluster</div>
       </div>

--- a/pkg/vcluster-rancher-extension-ui/pages/index.vue
+++ b/pkg/vcluster-rancher-extension-ui/pages/index.vue
@@ -561,11 +561,11 @@ export default defineComponent({
             <template #header-middle>
               <div class="table-heading">
                 <button
-                  class="btn btn-sm role-primary"
+                  class="btn btn-sm role-primary vcluster-create-btn"
                   @click="openCreateDialog"
                   data-testid="vcluster-create-button"
                 >
-                  Create vCluster
+                  <img src="../assets/vclusterLogoWhite.svg" alt="" class="vcluster-btn-icon" />Create vCluster
                 </button>
               </div>
             </template>
@@ -652,8 +652,25 @@ export default defineComponent({
 </template>
 
 <style lang="css">
+/* Keep the orange icon by default (img tag case) */
 .option img[src*="vclusterLogo"] {
   filter: none !important;
+}
+
+/* White icon on active/selected blue button (img tag case) */
+.btn-primary .option img[src*="vclusterLogo"],
+.option.selected img[src*="vclusterLogo"],
+.option.active img[src*="vclusterLogo"],
+.cluster-icon-menu-selected img[src*="vclusterLogo"] {
+  filter: brightness(0) invert(1) !important;
+}
+
+/* White icon on active/selected blue button (inline SVG case) */
+.btn-primary .option svg .st0,
+.option.selected svg .st0,
+.option.active svg .st0,
+.cluster-icon-menu-selected svg .st0 {
+  fill: #fff !important;
 }
 
 .bg-neutral {
@@ -742,6 +759,40 @@ export default defineComponent({
 
 .col-name {
   max-width: 280px;
+}
+
+.vcluster-btn-icon {
+  vertical-align: middle;
+  margin-right: 6px;
+  width: 16px;
+  height: 16px;
+}
+
+.vcluster-create-btn {
+  background-color: rgb(255, 102, 0);
+  border-color: rgb(255, 102, 0);
+
+  &:hover, &:focus {
+    background-color: rgb(220, 88, 0);
+    border-color: rgb(220, 88, 0);
+  }
+}
+
+.vcluster-create-btn--home {
+  margin-left: 10px;
+}
+
+/* vCluster nav icon: orange background + white logo when active or hovered */
+a.option[href*="/vCluster/"].router-link-active,
+a.option[href*="/vCluster/"].active-menu-link,
+a.option[href*="/vCluster/"]:hover {
+  background: rgb(255, 102, 0) !important;
+}
+
+a.option[href*="/vCluster/"].router-link-active img.svg-icon,
+a.option[href*="/vCluster/"].active-menu-link img.svg-icon,
+a.option[href*="/vCluster/"]:hover img.svg-icon {
+  filter: brightness(0) invert(1) !important;
 }
 
 .list-cluster-name {

--- a/pkg/vcluster-rancher-extension-ui/setupButtonInjector.js
+++ b/pkg/vcluster-rancher-extension-ui/setupButtonInjector.js
@@ -1,3 +1,5 @@
+const vclusterLogoWhite = require('./assets/vclusterLogoWhite.svg');
+
 export function setupButtonInjector() {
   const addVClusterButton = () => {
     const button = document.querySelector(
@@ -12,19 +14,16 @@ export function setupButtonInjector() {
       const copiedButton = button.cloneNode(true);
 
       if (copiedButton) {
-        copiedButton.classList.add("btn", "btn-sm", "role-primary");
+        copiedButton.classList.add("btn", "btn-sm", "role-primary", "vcluster-create-btn", "vcluster-create-btn--home");
         copiedButton.setAttribute("data-testid", "vcluster-create-button");
-        copiedButton.setAttribute("href", "/vCluster/c/_/dashboard");
-        copiedButton.setAttribute(
-          "style",
-          "margin-left: 10px;background-color: rgb(255, 102, 0)",
-        );
-        copiedButton.textContent = "Create vCluster";
+        const base = window.location.pathname.startsWith("/dashboard") ? "/dashboard" : "";
+        copiedButton.setAttribute("href", `${base}/vCluster/c/_/dashboard`);
+        copiedButton.innerHTML = `<img src="${vclusterLogoWhite}" alt="" class="vcluster-btn-icon">Create vCluster`;
 
         copiedButton.addEventListener("click", (e) => {
           e.preventDefault();
-          // This will break it locally, but works in prod. No way for me to determine if we're on a local env or prod.
-          window.location.href = "/dashboard/vCluster/c/_/dashboard";
+          const base = window.location.pathname.startsWith("/dashboard") ? "/dashboard" : "";
+          window.location.href = `${base}/vCluster/c/_/dashboard`;
         });
 
         const parent = button.parentElement;


### PR DESCRIPTION
Replace nav and create page icons with updated 24x24 SVGs provided by
design. Add white vCluster logo to the homepage and virtual clusters
page create buttons. Fix homepage button navigation path to work in
both local dev and production environments. Update logo on vCluster
provider card on the cluster create page. Change vcluster extension
hover effect to be a white logo on orange background.

Fixes ENGOX-141