### PR TITLE
fix(ci): checkout main branch in publish-chart job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,9 +88,12 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout main branch
         uses: actions/checkout@v4
-        
+        with:
+          ref: main
+          fetch-depth: 0
+
       - name: Setup Helm
         uses: azure/setup-helm@v4
         with:
@@ -105,21 +108,18 @@ jobs:
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/v!!p')
           
-          # Need to use loft-bot wit admin permissions to push to main
           git config --global user.name "loft-bot"
           git config --global user.email "github@loft.sh"
-          
+
           yq e -i ".version = \"${RELEASE_VERSION}\"" charts/vcluster-rancher-extension-ui/Chart.yaml
           yq e -i ".appVersion = \"${RELEASE_VERSION}\"" charts/vcluster-rancher-extension-ui/Chart.yaml
           yq e -i ".extension.version = \"${RELEASE_VERSION}\"" charts/vcluster-rancher-extension-ui/values.yaml
-          
-          # Commit changes back to the repository
+
           git add charts/vcluster-rancher-extension-ui/
           git commit -m "chore(chart): update chart version to ${RELEASE_VERSION}"
-          
-          # Use token for authentication
+
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/loft-sh/vcluster-rancher-extension-ui.git
-          git push --force-with-lease origin HEAD:main
+          git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
@@ -118,10 +119,10 @@ jobs:
           git add charts/vcluster-rancher-extension-ui/
           git commit -m "chore(chart): update chart version to ${RELEASE_VERSION}"
 
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/loft-sh/vcluster-rancher-extension-ui.git
+          git remote set-url origin https://x-access-token:${GH_ACCESS_TOKEN}@github.com/loft-sh/vcluster-rancher-extension-ui.git
           git push origin main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           
       - name: Publish Helm chart
         run: |


### PR DESCRIPTION
## Summary

Fixes the `publish-chart` job in the release workflow which fails with `! [rejected] HEAD -> main (stale info)`.

**Two root causes:**

1. **Stale ref**: The release workflow triggers on tag creation. The `publish-chart` job defaulted to checking out the tag ref (detached HEAD). `git push --force-with-lease origin HEAD:main` fails because the local `main` ref is stale.

2. **Token permissions**: The workflow used `secrets.GITHUB_TOKEN` which cannot bypass branch protection on public repos. The org-standard `secrets.GH_ACCESS_TOKEN` (loft-bot PAT) should be used instead — this is the pattern across loft-sh repos (vcluster, vcluster-docs, loft-enterprise).

**Fix:**
- Explicitly checkout `main` branch instead of the tag ref
- Use `secrets.GH_ACCESS_TOKEN` for both checkout and push (loft-bot PAT with bypass permissions)
- Use plain `git push origin main` instead of `--force-with-lease origin HEAD:main`

Failed run: https://github.com/loft-sh/vcluster-rancher-extension-ui/actions/runs/22465089309/job/65069150472

Closes DEVOPS-628